### PR TITLE
Reverting CSS theme naming

### DIFF
--- a/docs/css/design.css
+++ b/docs/css/design.css
@@ -74,7 +74,7 @@
     --md-primary-fg-color--dark: var(--night400);
 }
 :root,
-[data-md-color-scheme="percona-light"] {
+[data-md-color-scheme="default"] {
 
     /* Primitives */
     --md-hue: 220;
@@ -108,7 +108,7 @@
     /* Tables */
     --md-typeset-table-color: hsla(var(--md-hue),17%,21%,0.25)
 }
-[data-md-color-scheme="percona-dark"] {
+[data-md-color-scheme="slate"] {
 
     /* Primitives */
     --md-hue: 0;
@@ -274,7 +274,7 @@
     color: var(--md-typeset-color);
 }
 .md-button code,
-[data-md-color-scheme="percona-dark"] .md-button:not(.md-button--primary) code {
+[data-md-color-scheme="slate"] .md-button:not(.md-button--primary) code {
     background-color: rgba(255, 255, 255, 0.1);
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1) inset;
 }

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -24,14 +24,14 @@ theme:
         icon: material/brightness-auto
         name: Color theme set to Automatic. Click to change
     - media: "(prefers-color-scheme: light)"
-      scheme: percona-light
+      scheme: default
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-7
         name: Color theme set to Light Mode. Click to change
     - media: "(prefers-color-scheme: dark)"
-      scheme: percona-dark
+      scheme: slate
       primary: custom
       accent: custom
       toggle:


### PR DESCRIPTION
The idea is to fix and inherit the original logic for theme switching that is way buried inside Material for MkDocs and associated to "default" and "slate"