### PR TITLE
K8SPS-613 Fixed linlks to yaml manifests to point to the release instead of the main branch

### DIFF
--- a/docs/ReleaseNotes/Kubernetes-Operator-for-PS-RN0.6.0.md
+++ b/docs/ReleaseNotes/Kubernetes-Operator-for-PS-RN0.6.0.md
@@ -29,7 +29,7 @@ Percona Operator for MySQL allows users to deploy MySQL clusters with both async
 * {{ k8spsjira(205) }}: Update user passwords on a per-user basis instead of a cumulative update so that if an error occurs while changing a user's password, other system users are not affected
 * {{ k8spsjira(270) }}: Use more clear [Controller :octicons-link-external-16:](https://kubernetes.io/docs/concepts/architecture/controller/) names in log messages to ease troubleshooting
 * {{ k8spsjira(280) }}: Full cluster crash recovery with group replication is now using MySQL shell built-in checks to detect the member with latest transactions and reboots from it, making the cluster prone to data loss
-* {{ k8spsjira(281) }}: The Operator [can now be run locally :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/CONTRIBUTING.md#1-contributing-to-the-source-tree) against a remote Kubernetes cluster, which simplifies the development process, substantially shortening the way to make and try minor code improvements
+* {{ k8spsjira(281) }}: The Operator [can now be run locally :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/CONTRIBUTING.md#1-contributing-to-the-source-tree) against a remote Kubernetes cluster, which simplifies the development process, substantially shortening the way to make and try minor code improvements
 
 ## Bugs Fixed
 

--- a/docs/ReleaseNotes/Kubernetes-Operator-for-PS-RN0.7.0.md
+++ b/docs/ReleaseNotes/Kubernetes-Operator-for-PS-RN0.7.0.md
@@ -31,7 +31,7 @@ With our latest release, we put an all-hands-on-deck approach towards fine-tunin
 
 ## Improvements
 
-* {{ k8spsjira(129) }}: The documentation on how to build and test the Operator [is now available :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/e2e-tests/README.md)
+* {{ k8spsjira(129) }}: The documentation on how to build and test the Operator [is now available :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/e2e-tests/README.md)
 * {{ k8spsjira(295) }}: Certificate issuer errors are now reflected in the Custom Resource status message and can be easily checked with the `kubectl get ps -o yaml` command
 * {{ k8spsjira(326) }}: The mysql-monit Orchestrator sidecar container now inherits orchestrator resources following the way that HAProxy mysql-monit container does (thanks to SlavaUtesinov for contribution)
 

--- a/docs/backup-tutorial.md
+++ b/docs/backup-tutorial.md
@@ -44,7 +44,7 @@ cd percona-server-mysql-operator
         echo -n 'AWS_SECRET_ACCESS_KEY' | base64 
         ```
 
-2. Edit the [deploy/backup/backup-s3.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/backup/backup-s3.yaml) example Secrets configuration file and specify the following:
+2. Edit the [deploy/backup/backup-s3.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/backup/backup-s3.yaml) example Secrets configuration file and specify the following:
 
     * the `metadata.name` key is the name which you use to refer your Kubernetes Secret
     * the base64-encoded S3 credentials
@@ -108,7 +108,7 @@ Now when you have the [configured storage](#configure-backup-storage) in your
 Custom Resource, you can make your first backup.
 {.power-number}
 
-1. To make a backup, you need the configuration file. Edit the sample [deploy/backup/backup.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/backup/backup.yaml) configuration file and specify the following:
+1. To make a backup, you need the configuration file. Edit the sample [deploy/backup/backup.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/backup/backup.yaml) configuration file and specify the following:
 
     * `metadata.name` - specify the backup name. You will use this name to restore from this backup
     * `spec.clusterName` - specify the name of your cluster. This is the name you specified when deploying Percona Server for MySQL cluster.

--- a/docs/backups-ondemand.md
+++ b/docs/backups-ondemand.md
@@ -17,7 +17,7 @@ contains correctly configured keys and is applied with `kubectl` command, use
 
 * <a name="finalizers"></a>**S3 backup finalizer** set by the `metadata.finalizers.percona.com/delete-backup` key (it triggers the actual deletion of backup files from the S3 bucket when there is a manual or scheduled removal of the corresponding backup object).
 
-The example of such file is [deploy/backup/backup.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/backup/backup.yaml).
+The example of such file is [deploy/backup/backup.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/backup/backup.yaml).
 
 When the backup destination is configured and applied with kubectl apply -f deploy/cr.yaml command, make backup as follows:
 

--- a/docs/backups-restore.md
+++ b/docs/backups-restore.md
@@ -9,7 +9,7 @@ also on any Kubernetes-based environment with the installed Operator.
     has a Secrets object with the same user passwords as in the original cluster.
     More details about secrets can be found in [System Users](users.md#system-users).
 
-The example of the restore configuration file is [deploy/backup/restore.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/backup/restore.yaml). The options that can be used in it are described in the [restore options reference](restore-cr.md).
+The example of the restore configuration file is [deploy/backup/restore.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/backup/restore.yaml). The options that can be used in it are described in the [restore options reference](restore-cr.md).
 
 Following things are needed to restore a previously saved backup:
 

--- a/docs/backups-scheduled.md
+++ b/docs/backups-scheduled.md
@@ -2,7 +2,7 @@
  
 
 Backups schedule is defined in the `backup` section of the Custom
-Resource and can be configured via the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+Resource and can be configured via the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
 file.
 
 1. The `backup.storages` subsection should contain at least one [configured storage](backups-storage.md).

--- a/docs/backups-storage.md
+++ b/docs/backups-storage.md
@@ -1,7 +1,7 @@
 # Configure storage for backups
 
 You can configure storage for backups in the `backup.storages` subsection of the
-Custom Resource, using the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+Custom Resource, using the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
 configuration file.
 
 You should also create the [Kubernetes Secret :octicons-link-external-16:](https://kubernetes.io/docs/concepts/configuration/secret/)
@@ -12,7 +12,7 @@ object with credentials needed to access the storage.
     Since backups are stored separately on the Amazon S3, a secret with
     `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` should be present on
     the Kubernetes cluster. The secrets file with these base64-encoded keys should
-    be created: for example [deploy/backup/backup-s3.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/backup/backup-s3.yaml) file with the following
+    be created: for example [deploy/backup/backup-s3.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/backup/backup-s3.yaml) file with the following
     contents.
 
     ```yaml
@@ -54,7 +54,7 @@ object with credentials needed to access the storage.
 
     All the data needed to access the S3-compatible cloud to store backups should be
     put into the `backup.storages` subsection. Here is an example
-    of [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+    of [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
     which uses Amazon S3 storage for backups:
 
     ```yaml
@@ -140,7 +140,7 @@ object with credentials needed to access the storage.
 
     All the data needed to access the Azure Blob storage to store backups should be
     put into the `backup.storages` subsection. Here is an example
-    of [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+    of [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
     which uses Azure Blob storage for backups:
 
     ```yaml

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -9,7 +9,7 @@ or on [Azure Blob Storage :octicons-link-external-16:](https://azure.microsoft.c
 The Operator does physical backups using the [Percona XtraBackup :octicons-link-external-16:](https://docs.percona.com/percona-xtrabackup/latest/) tool.
 
 Backups are controlled by the `backup` section of the
-[deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+[deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
 file. This section contains the [backup.enabled](operator.md#backupenabled) key
 (it should be set to `true` to enable backups), and the number of options in the
 `storages` subsection, [needed to access cloud to store backups](backups-storage.md).
@@ -17,7 +17,7 @@ file. This section contains the [backup.enabled](operator.md#backupenabled) key
 The Operator allows doing backups in two ways:
 
 * *Scheduled backups* are configured in the
-    [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+    [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
     file to be executed automatically in proper time.
 * *On-demand backups* can be done manually at any moment and are configured in
-    the [deploy/backup/backup.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/backup/backup.yaml).
+    the [deploy/backup/backup.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/backup/backup.yaml).

--- a/docs/haproxy-conf.md
+++ b/docs/haproxy-conf.md
@@ -91,5 +91,5 @@ haproxy:
       http-request use-service prometheus-exporter if { path /metrics }
 ```
 
-the actual default configuration file can be found [here :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/build/haproxy-global.cfg).
+the actual default configuration file can be found [here :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/build/haproxy-global.cfg).
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -9,8 +9,7 @@ Percona Operator for MySQL uses [Custom Resources :octicons-link-external-16:](h
 ## PerconaServerMySQL Custom Resource options
 
 Percona Server for MySQL managed by the Operator is configured via the spec section
-of the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
-file.
+of the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file.
 
 The metadata part of PerconaServerMySQL Custom Resource contains the following keys:
 
@@ -26,11 +25,11 @@ alphanumeric character;
     * `percona.com/delete-ssl` if present, activates the [Finalizer :octicons-link-external-16:](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers) which deletes [objects, created for SSL](TLS.md) (Secret, certificate, and issuer) after the cluster deletion event (off by default).
 
 
-The top-level spec elements of the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) are the following ones:
+The top-level spec elements of the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) are the following ones:
 
 ## Toplevel `spec` elements
 
-The spec part of the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-postgresql-operator/blob/main/deploy/cr.yaml) file contains the following:
+The spec part of the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains the following:
 
 ### `crVersion`
 
@@ -178,7 +177,7 @@ Prevents users from configuring a cluster with unsafe parameters such as startin
 
 ## <a name="operator-unsafeflags-section"></a>Unsafe flags section
 
-The `unsafeFlags` section in the [deploy/cr.yaml  :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains various configuration options to prevent users from configuring a cluster with unsafe parameters. *After switching to unsafe configurations permissive mode you will not be able to switch the cluster back by setting same keys to `false`, the flags will be ignored*.
+The `unsafeFlags` section in the [deploy/cr.yaml  :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains various configuration options to prevent users from configuring a cluster with unsafe parameters. *After switching to unsafe configurations permissive mode you will not be able to switch the cluster back by setting same keys to `false`, the flags will be ignored*.
 
 ### `unsafeFlags.mysqlSize`
 
@@ -222,7 +221,7 @@ Allows users to set [orchestrator.size](#orchestratorsize) option to a value les
 
 ## <a name="operator-issuerconf-section"></a>Extended cert-manager configuration section
 
-The `tls` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains various configuration options for additional customization of the [TLS cert-manager](TLS.md#install-and-use-the-cert-manager).
+The `tls` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains various configuration options for additional customization of the [TLS cert-manager](TLS.md#install-and-use-the-cert-manager).
 
 ### `tls.SANs`
 
@@ -258,7 +257,7 @@ A [cert-manager issuer group :octicons-link-external-16:](https://cert-manager.i
 
 ## <a name="operator-upgrade-options-section"></a>Upgrade options section
 
-The `upgradeOptions` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains various configuration options to control Percona Server for MySQL version choice at the deployment time and during upgrades.
+The `upgradeOptions` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains various configuration options to control Percona Server for MySQL version choice at the deployment time and during upgrades.
 
 ### `upgradeOptions.versionServiceEndpoint`
 
@@ -278,7 +277,7 @@ Specifies how images are picked up from the version service on initial start by 
 
 ## <a name="operator-mysql-section"></a>Percona Server for MySQL section
 
-The `mysql` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains general
+The `mysql` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains general
 configuration options for the Percona Server for MySQL.
 
 ### `mysql.clusterType`
@@ -927,7 +926,7 @@ Name of the [custom sidecar container](sidecar.md) volume for Replica Set Pods.
 
 ## <a name="operator-haproxy-section"></a>HAProxy subsection
 
-The `proxy.haproxy` subsection in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+The `proxy.haproxy` subsection in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
 file contains configuration options for the HAProxy service.
 
 ### `proxy.haproxy.enabled`
@@ -1337,7 +1336,7 @@ A custom [Kubernetes Security Context for a Pod :octicons-link-external-16:](htt
 
 ## <a name="operator-router-section"></a>Router subsection
 
-The `proxy.router` subsection in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains configuration options for the [MySQL Router :octicons-link-external-16:](https://dev.mysql.com/doc/mysql-router/8.0/en/), which can act as a proxy for Group replication.
+The `proxy.router` subsection in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains configuration options for the [MySQL Router :octicons-link-external-16:](https://dev.mysql.com/doc/mysql-router/8.0/en/), which can act as a proxy for Group replication.
 
 ### `proxy.router.enabled`
 
@@ -1669,7 +1668,7 @@ The range of client IP addresses from which the load balancer should be reachabl
 
 ## <a name="operator-orchestrator-section"></a>Orchestrator section
 
-The `orchestrator` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains
+The `orchestrator` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains
 configuration options for the Orchestrator - a replication topology manager, used if asynchronous replication is turned on.
 
 ### `orchestrator.enabled`
@@ -2121,7 +2120,7 @@ The [Kubernetes PersistentVolumeClaim :octicons-link-external-16:](https://kuber
 
 ## <a name="operator-pmm-section"></a>PMM section
 
-The `pmm` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains configuration
+The `pmm` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains configuration
 options for Percona Monitoring and Management.
 
 ### `pmm.enabled`
@@ -2278,7 +2277,7 @@ Address of the PMM Server to collect data from the cluster.
 
 ## <a name="operator-backup-section"></a>Backup section
 
-The `backup` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml)
+The `backup` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml)
 file contains the following configuration options for the regular Percona XtraDB Cluster backups.
 
 ### `backup.enabled`
@@ -2668,7 +2667,7 @@ The name of the storage for the backups configured in the `storages` subsection.
 
 ## <a name="operator-pt-section"></a>Percona Toolkit section
 
-The `toolkit` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/main/deploy/cr.yaml) file contains configuration
+The `toolkit` section in the [deploy/cr.yaml :octicons-link-external-16:](https://github.com/percona/percona-server-mysql-operator/blob/v{{release}}/deploy/cr.yaml) file contains configuration
 options for [Percona Toolkit :octicons-link-external-16:](https://docs.percona.com/percona-toolkit/).
 
 ### `toolkit.image`


### PR DESCRIPTION


 modified:   docs/ReleaseNotes/Kubernetes-Operator-for-PS-RN0.6.0.md
        modified:   docs/ReleaseNotes/Kubernetes-Operator-for-PS-RN0.7.0.md
        modified:   docs/backup-tutorial.md
        modified:   docs/backups-ondemand.md
        modified:   docs/backups-restore.md
        modified:   docs/backups-scheduled.md
        modified:   docs/backups-storage.md
        modified:   docs/backups.md
        modified:   docs/haproxy-conf.md
        modified:   docs/operator.md