### PR TITLE
Fix formatting of kubectl command in backup tutorial

### DIFF
--- a/docs/backup-tutorial.md
+++ b/docs/backup-tutorial.md
@@ -62,9 +62,9 @@ cd percona-server-mysql-operator
 
 3. Create the Secrets object from this yaml file. Specify your namespace instead of the `<namespace>` placeholder:
 
-	```bash
-  kubectl apply -f deploy/backup/backup-secret-s3.yaml -n <namespace>
-	```
+    ```bash
+    kubectl apply -f deploy/backup/backup-secret-s3.yaml -n <namespace>
+    ```
 
 4. Update your `deploy/cr.yaml` configuration. Specify the following parameters in the `backup` section:
 


### PR DESCRIPTION
Bad indent breaks the code block.

<img width="701" height="102" alt="image" src="https://github.com/user-attachments/assets/cb1b55d4-7928-4dc7-9635-65198d17f678" />
