### PR TITLE
Update apiVersion in backup tutorial

### DIFF
--- a/docs/backup-tutorial.md
+++ b/docs/backup-tutorial.md
@@ -115,7 +115,7 @@ Custom Resource, you can make your first backup.
     * `spec.storageName` - specify the name of your already configured storage.
 
     ```yaml title="deploy/backup/backup.yaml"
-    apiVersion: ps.percona.com/v1alpha1
+    apiVersion: ps.percona.com/v1
     kind: PerconaServerMySQLBackup
     metadata:
       name: backup1


### PR DESCRIPTION
Fixes error:
```bash
$ kubectl apply -f deploy/backup/backup.yaml --dry_run=client
error: resource mapping not found for name: "backup1" namespace: "" from "deploy/backup/backup.yaml": no matches for kind "PerconaServerMySQLBackup" in version "ps.percona.com/v1alpha1"
ensure CRDs are installed first
```