### PR TITLE
Fix indentation in backup tutorial commands

### DIFF
--- a/docs/backup-tutorial.md
+++ b/docs/backup-tutorial.md
@@ -129,14 +129,14 @@ Custom Resource, you can make your first backup.
 2. Apply the configuration. This instructs the Operator to start a backup. Specify your namespace instead of the `<namespace>` placeholder:
 
     ```bash
-	  kubectl apply -f deploy/backup/backup.yaml -n <namespace>
-	  ```
+    kubectl apply -f deploy/backup/backup.yaml -n <namespace>
+    ```
 
 3. Track the backup progress. 
 
     ```bash
-	  kubectl get ps-backup -n <namespace>
-	  ```
+    kubectl get ps-backup -n <namespace>
+    ```
 
 	??? example "Output"
 


### PR DESCRIPTION
Bad indent breaks the code block.
<img width="429" height="175" alt="image" src="https://github.com/user-attachments/assets/4a9199e9-5da4-42d2-bdfe-bdd41b584d45" />
