### PR TITLE
Note QAN prepared-statement visibility for Operator-managed MySQL

### DIFF
--- a/docs/assets/fragments/monitor-db.txt
+++ b/docs/assets/fragments/monitor-db.txt
@@ -13,6 +13,7 @@ PMM Server and PMM Client are installed separately.
 1. Starting with the version 0.10.0, the Operator supports only PMM 3.x versions. The support for PMM 2.x is dropped.
 2. You must run the Operator version 0.10.0 and later to monitor your database with PMM 3.x. Check the [Upgrade the Operator](update-operator.md) tutorial for the update steps.
 3. To use PMM3, PMM Server version must be equal to or newer than the PMM Client.
+4. Query Analytics (QAN) reads MySQL queries from Performance Schema, which the Operator configures for each node. If your applications use server-side prepared statements (common with drivers such as JDBC), expect QAN to show query examples as placeholders (`?`) rather than literal values, and EXPLAIN to be unavailable for them. This is how upstream MySQL exposes prepared statements to Performance Schema — expected behavior, not a limitation of PMM or the Operator.
 
 ## Install PMM Server
 

--- a/docs/assets/fragments/monitor-db.txt
+++ b/docs/assets/fragments/monitor-db.txt
@@ -13,7 +13,7 @@ PMM Server and PMM Client are installed separately.
 1. Starting with the version 0.10.0, the Operator supports only PMM 3.x versions. The support for PMM 2.x is dropped.
 2. You must run the Operator version 0.10.0 and later to monitor your database with PMM 3.x. Check the [Upgrade the Operator](update-operator.md) tutorial for the update steps.
 3. To use PMM3, PMM Server version must be equal to or newer than the PMM Client.
-4. Query Analytics (QAN) reads MySQL queries from Performance Schema, which the Operator configures for each node. If your applications use server-side prepared statements (common with drivers such as JDBC), expect QAN to show query examples as placeholders (`?`) rather than literal values, and EXPLAIN to be unavailable for them. This is how upstream MySQL exposes prepared statements to Performance Schema — expected behavior, not a limitation of PMM or the Operator.
+4. Query Analytics (QAN) reads MySQL queries from Performance Schema, which the Operator configures for each node. If your applications use server-side prepared statements (common with drivers such as JDBC), expect QAN to show query examples as placeholders (`?`) rather than literal values, and EXPLAIN to be unavailable for them. This is how upstream MySQL exposes prepared statements to Performance Schema. This is expected behavior, not a limitation of PMM or the Operator.
 
 ## Install PMM Server
 


### PR DESCRIPTION
## What

Adds a short, expectation-setting note so readers recognize why PMM Query Analytics (QAN) may show incomplete data for MySQL prepared-statement workloads.

## Why

Server-side prepared statements (used by most application drivers, e.g. JDBC) are exposed by upstream MySQL to Performance Schema with placeholder parameters (`?`) rather than literal values. As a result, QAN query examples appear as placeholders and EXPLAIN is unavailable for them. This is upstream MySQL behavior, **not** a PMM limitation. The note helps users self-diagnose instead of assuming data is missing.

The Operator configures MySQL QAN via Performance Schema (`--query-source=perfschema`), so this is pure expectation-setting — there is no slow-log alternative to switch to. Edits the live included fragment, not the stale `snippets/monitor-db.md`.

## Scope

Documentation only — a single Considerations item in `docs/assets/fragments/monitor-db.txt`. Part of a coordinated set of PRs across pmm-doc, psmysql-docs, pxc-docs, k8sps-docs, and k8spxc-docs.

DCO: signed off.