### PR TITLE
Indentation fix for secret credential retrieval snippet

### DIFF
--- a/docs/assets/fragments/connectivity.txt
+++ b/docs/assets/fragments/connectivity.txt
@@ -23,10 +23,10 @@ Here's how to connect:
 3. Retrieve the user credentials from the Secret:
    
     ```bash
-{{ commandName }} get secret "$SECRET_NAME" -n "$NAMESPACE" \
-  -o jsonpath='{.data.user}' | base64 --decode && echo
-{{ commandName }} get secret "$SECRET_NAME" -n "$NAMESPACE" \
-  -o jsonpath='{.data.password}' | base64 --decode && echo
+    {{ commandName }} get secret "$SECRET_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.data.user}' | base64 --decode && echo
+    {{ commandName }} get secret "$SECRET_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.data.password}' | base64 --decode && echo
     ```
 
 


### PR DESCRIPTION
On the "Connect to the database" fragment, step 3 (fetching credentials from secret) has the incorrect indentation.  This gets the indent back inline and fixes the bash copy/paste section for fetching credentials.